### PR TITLE
build-workflow: add elixir and otp versions in cache keys

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -26,24 +26,21 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          ${{ runner.os }}-mix-
+          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-
     - uses: actions/cache@v1
       with:
         path: _build
-        key: ${{ runner.os }}-_build-${{ github.sha }}
+        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-_build-${{ github.sha }}
-          ${{ runner.os }}-_build-
+          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-
     - uses: actions/cache@v1
       with:
         path: dialyzer_cache
-        key: ${{ runner.os }}-dialyzer_cache-${{ github.sha }}
+        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-dialyzer_cache-${{ github.sha }}
-          ${{ runner.os }}-dialyzer_cache-
+          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}
@@ -80,17 +77,15 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          ${{ runner.os }}-mix-
+          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-
     - uses: actions/cache@v1
       with:
         path: _build
-        key: ${{ runner.os }}-_build-${{ github.sha }}
+        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-_build-${{ github.sha }}
-          ${{ runner.os }}-_build-
+          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}


### PR DESCRIPTION
Remove unneeded restore keys

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>