### PR TITLE
Don't crash when checking interface version but introspection is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - Unreleased
+### Fixed
+- Don't crash when retrieving the interface version
+  in a device whose introspection is empty.
+
 ## [1.1.0] - 2023-06-20
 
 ## [1.1.0-rc.0] - 2023-06-08

--- a/lib/astarte_data_access/device.ex
+++ b/lib/astarte_data_access/device.ex
@@ -47,6 +47,10 @@ defmodule Astarte.DataAccess.Device do
       [] ->
         {:error, :device_not_found}
 
+      # We're here if the device has been registered but has not declared its introspection yet
+      [%{introspection: nil}] ->
+        {:ok, %{}}
+
       [%{introspection: introspection}] ->
         {:ok, introspection}
     end


### PR DESCRIPTION
Fixes a regression introduced in 1.1.0-rc.0.