### PR TITLE
Allow to access Astarte keyspaces in a shared database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `ASTARTE_INSTANCE_ID` env to allow sharing
+  the database between multiple Astarte instances.
+  Default to `""` to maintain backward compatibility.
+
 ### Changed
 - Update Elixir to 1.15.7.
 - Update Erlang/OTP to 26.1.

--- a/lib/astarte_data_access/config.ex
+++ b/lib/astarte_data_access/config.ex
@@ -113,6 +113,16 @@ defmodule Astarte.DataAccess.Config do
     type: :boolean,
     default: false
 
+  @envdoc """
+  A string that uniquely identifies this Astarte instance.
+  It will be used to generate Scylla keyspaces starting from Astarte realm names.
+  Defaults to "".
+  """
+  app_env :astarte_instance_id, :astarte_data_access, :astarte_instance_id,
+    os_env: "ASTARTE_INSTANCE_ID",
+    default: "",
+    type: :binary
+
   defp populate_xandra_ssl_options(options) do
     if ssl_enabled!() do
       ssl_options = build_ssl_options()

--- a/lib/astarte_data_access/data.ex
+++ b/lib/astarte_data_access/data.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 - 2023 SECO Mind Srl
+# Copyright 2018 - 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,12 +48,12 @@ defmodule Astarte.DataAccess.Data do
     )
   end
 
-  defp do_fetch_property(conn, realm_name, device_id, interface_descriptor, mapping, path) do
+  defp do_fetch_property(conn, keyspace_name, device_id, interface_descriptor, mapping, path) do
     value_column = CQLUtils.type_to_db_column_name(mapping.value_type)
 
     statement = """
     SELECT #{value_column}
-    FROM #{realm_name}."#{interface_descriptor.storage}"
+    FROM #{keyspace_name}."#{interface_descriptor.storage}"
     WHERE device_id=:device_id AND interface_id=:interface_id
       AND endpoint_id=:endpoint_id AND path=:path
     """
@@ -108,11 +108,11 @@ defmodule Astarte.DataAccess.Data do
     )
   end
 
-  defp do_path_exists?(conn, realm_name, device_id, interface_descriptor, mapping, path) do
+  defp do_path_exists?(conn, keyspace_name, device_id, interface_descriptor, mapping, path) do
     # TODO: do not hardcode individual_properties here
     statement = """
     SELECT COUNT(*)
-    FROM #{realm_name}.#{@individual_properties_table}
+    FROM #{keyspace_name}.#{@individual_properties_table}
     WHERE device_id=:device_id AND interface_id=:interface_id
       AND endpoint_id=:endpoint_id AND path=:path
     """
@@ -175,7 +175,7 @@ defmodule Astarte.DataAccess.Data do
 
   defp do_fetch_last_path_update(
          conn,
-         realm_name,
+         keyspace_name,
          device_id,
          interface_descriptor,
          mapping,
@@ -184,7 +184,7 @@ defmodule Astarte.DataAccess.Data do
     # TODO: do not hardcode individual_properties here
     statement = """
     SELECT datetime_value, reception_timestamp, reception_timestamp_submillis
-    FROM #{realm_name}.#{@individual_properties_table}
+    FROM #{keyspace_name}.#{@individual_properties_table}
     WHERE device_id=:device_id AND interface_id=:interface_id
       AND endpoint_id=:endpoint_id AND path=:path
     """

--- a/lib/astarte_data_access/database.ex
+++ b/lib/astarte_data_access/database.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 Ispirata Srl
+# Copyright 2018 - 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ defmodule Astarte.DataAccess.Database do
   require Logger
 
   alias Astarte.DataAccess.Config
+  alias Astarte.Core.CQLUtils
 
   @spec connect(realm: String.t(), cassandra_nodes: list) ::
           {:ok, :cqerl.client()} | {:error, atom}
@@ -60,8 +61,10 @@ defmodule Astarte.DataAccess.Database do
   defp get_client_opts(opts) do
     case Keyword.fetch(opts, :realm) do
       {:ok, realm} ->
+        keyspace = CQLUtils.realm_name_to_keyspace_name(realm, Config.astarte_instance_id!())
+
         Config.cqex_options!()
-        |> Keyword.put(:keyspace, realm)
+        |> Keyword.put(:keyspace, keyspace)
 
       :error ->
         Config.cqex_options!()

--- a/lib/astarte_data_access/device.ex
+++ b/lib/astarte_data_access/device.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 - 2023 SECO Mind Srl
+# Copyright 2018 - 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ defmodule Astarte.DataAccess.Device do
     XandraUtils.run(realm, &do_interface_version(&1, &2, device_id, interface_name))
   end
 
-  defp do_interface_version(conn, realm_name, device_id, interface_name) do
+  defp do_interface_version(conn, keyspace_name, device_id, interface_name) do
     statement = """
     SELECT introspection
-    FROM #{realm_name}.devices
+    FROM #{keyspace_name}.devices
     WHERE device_id=:device_id
     """
 

--- a/lib/astarte_data_access/interface.ex
+++ b/lib/astarte_data_access/interface.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 - 2023 SECO Mind Srl
+# Copyright 2018 - 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ defmodule Astarte.DataAccess.Interface do
     )
   end
 
-  def do_retrieve_interface_row(conn, realm_name, interface_name, major_version, opts) do
+  def do_retrieve_interface_row(conn, keyspace_name, interface_name, major_version, opts) do
     selector = if opts[:include_docs], do: "*", else: @interface_row_default_selector
 
     statement = """
     SELECT #{selector}
-    FROM #{realm_name}.interfaces
+    FROM #{keyspace_name}.interfaces
     WHERE name=:name AND major_version=:major_version
     """
 
@@ -74,10 +74,10 @@ defmodule Astarte.DataAccess.Interface do
     )
   end
 
-  defp do_check_if_interface_exists(conn, realm_name, interface_name, major_version) do
+  defp do_check_if_interface_exists(conn, keyspace_name, interface_name, major_version) do
     statement = """
     SELECT COUNT(*)
-    FROM #{realm_name}.interfaces
+    FROM #{keyspace_name}.interfaces
     WHERE name=:name AND major_version=:major_version
     """
 

--- a/lib/astarte_data_access/mappings.ex
+++ b/lib/astarte_data_access/mappings.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 - 2023 SECO Mind Srl
+# Copyright 2018 - 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ defmodule Astarte.DataAccess.Mappings do
     XandraUtils.run(realm, &do_fetch_interface_mappings(&1, &2, interface_id, opts))
   end
 
-  defp do_fetch_interface_mappings(conn, realm_name, interface_id, opts) do
+  defp do_fetch_interface_mappings(conn, keyspace_name, interface_id, opts) do
     include_docs =
       if Keyword.get(opts, :include_docs) do
         ", doc, description"
@@ -39,7 +39,7 @@ defmodule Astarte.DataAccess.Mappings do
     SELECT endpoint, value_type, reliability, retention, database_retention_policy,
       database_retention_ttl, expiry, allow_unset, explicit_timestamp, endpoint_id,
       interface_id #{include_docs}
-    FROM #{realm_name}.endpoints
+    FROM #{keyspace_name}.endpoints
     WHERE interface_id=:interface_id
     """
 

--- a/lib/astarte_data_access/xandra_utils.ex
+++ b/lib/astarte_data_access/xandra_utils.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023 - 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,13 +18,18 @@
 
 defmodule Astarte.DataAccess.XandraUtils do
   alias Astarte.Core.Realm
+  alias Astarte.Core.CQLUtils
+  alias Astarte.DataAccess.Config
+
   require Logger
 
   @spec run(String.t(), (Xandra.Connection.t(), String.t() -> any)) ::
           any | {:error, :invalid_realm_name}
   def run(realm, fun) do
     with :ok <- verify_realm(realm) do
-      Xandra.Cluster.run(:astarte_data_access_xandra, &fun.(&1, realm))
+      keyspace = CQLUtils.realm_name_to_keyspace_name(realm, Config.astarte_instance_id!())
+
+      Xandra.Cluster.run(:astarte_data_access_xandra, &fun.(&1, keyspace))
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "685ca10c7a07cc9806f2c6fc7ec2ed1b4d23cbec", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "dc964b7d9b3a3a4e20127b763705d9e53bd88890", []},
   "castore": {:hex, :castore, "0.1.9", "eb08a94c12ebff92a92d844c6ccd90728dc7662aab9bdc8b3b785ba653c499d5", [:mix], [], "hexpm", "99c3a38ad9c0bab03fee1418c98390da1a31f3b85e317db5840d51a1443d26c8"},
   "certifi": {:hex, :certifi, "2.6.1", "dbab8e5e155a0763eea978c913ca280a6b544bfa115633fa20249c3d396d9493", [:rebar3], [], "hexpm", "524c97b4991b3849dd5c17a631223896272c6b0af446778ba4675a1dff53bb7e"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},


### PR DESCRIPTION
 This PR is in the context of https://github.com/astarte-platform/astarte/issues/924.
 
Introduce the `ASTARTE_INSTANCE_ID` env var to distinguish the different instance we're in (default to "" to maintain backward compatibility).
