### PR TITLE
Standard consistency level in queries

### DIFF
--- a/lib/astarte_data_access/consistency.ex
+++ b/lib/astarte_data_access/consistency.ex
@@ -1,0 +1,38 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataAccess.Consistency do
+  alias Astarte.Core.Mapping
+  alias Astarte.DataAccess.Config
+
+  def domain_model(:read), do: Config.domain_model_read_consistency!()
+  def domain_model(:write), do: Config.domain_model_write_consistency!()
+
+  def device_info(:read), do: Config.device_info_read_consistency!()
+  def device_info(:write), do: Config.device_info_write_consistency!()
+
+  # TODO Xandra does not support :any consistency. Use the standard approach
+  # when https://github.com/whatyouhide/xandra/issues/380 is closed.
+  def time_series(:write, %Mapping{reliability: :unreliable}) do
+    :one
+  end
+
+  def time_series(operation, mapping) do
+    Config.time_series_consistency(operation, mapping)
+  end
+end

--- a/lib/astarte_data_access/data.ex
+++ b/lib/astarte_data_access/data.ex
@@ -18,6 +18,7 @@
 
 defmodule Astarte.DataAccess.Data do
   require Logger
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.XandraUtils
   alias Astarte.Core.CQLUtils
   alias Astarte.Core.Device
@@ -65,8 +66,10 @@ defmodule Astarte.DataAccess.Data do
       path: path
     }
 
+    consistency = Consistency.device_info(:read)
+
     with {:ok, %Xandra.Page{} = page} <-
-           XandraUtils.retrieve_page(conn, statement, params, consistency: :quorum) do
+           XandraUtils.retrieve_page(conn, statement, params, consistency: consistency) do
       retrieve_property_value(page, value_column)
     end
   end
@@ -124,8 +127,10 @@ defmodule Astarte.DataAccess.Data do
       path: path
     }
 
+    consistency = Consistency.domain_model(:read)
+
     with {:ok, %Xandra.Page{} = page} <-
-           XandraUtils.retrieve_page(conn, statement, params, consistency: :quorum),
+           XandraUtils.retrieve_page(conn, statement, params, consistency: consistency),
          {:ok, value} <- retrieve_path_count(page) do
       case value do
         0 ->
@@ -196,8 +201,10 @@ defmodule Astarte.DataAccess.Data do
       path: path
     }
 
+    consistency = Consistency.device_info(:read)
+
     with {:ok, %Xandra.Page{} = page} <-
-           XandraUtils.retrieve_page(conn, statement, params, consistency: :quorum) do
+           XandraUtils.retrieve_page(conn, statement, params, consistency: consistency) do
       retrieve_last_path_update(page)
     end
   end

--- a/lib/astarte_data_access/device.ex
+++ b/lib/astarte_data_access/device.ex
@@ -18,6 +18,7 @@
 
 defmodule Astarte.DataAccess.Device do
   require Logger
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.XandraUtils
   alias Astarte.Core.Device
 
@@ -34,8 +35,12 @@ defmodule Astarte.DataAccess.Device do
     WHERE device_id=:device_id
     """
 
+    consistency = Consistency.device_info(:read)
+
     with {:ok, %Xandra.Page{} = page} <-
-           XandraUtils.retrieve_page(conn, statement, %{device_id: device_id}),
+           XandraUtils.retrieve_page(conn, statement, %{device_id: device_id},
+             consistency: consistency
+           ),
          {:ok, introspection} <- retrieve_introspection(page),
          {:ok, major} <- retrieve_major(introspection, interface_name) do
       {:ok, major}

--- a/lib/astarte_data_access/interface.ex
+++ b/lib/astarte_data_access/interface.ex
@@ -19,6 +19,7 @@
 defmodule Astarte.DataAccess.Interface do
   require Logger
   alias Astarte.Core.InterfaceDescriptor
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.XandraUtils
 
   @interface_row_default_selector "name, major_version, minor_version, interface_id, type, ownership, aggregation,
@@ -47,8 +48,10 @@ defmodule Astarte.DataAccess.Interface do
       major_version: major_version
     }
 
+    consistency = Consistency.domain_model(:read)
+
     with {:ok, %Xandra.Page{} = page} <-
-           XandraUtils.retrieve_page(conn, statement, params) do
+           XandraUtils.retrieve_page(conn, statement, params, consistency: consistency) do
       case Enum.to_list(page) do
         [] -> {:error, :interface_not_found}
         [row] -> {:ok, row}
@@ -86,7 +89,10 @@ defmodule Astarte.DataAccess.Interface do
       major_version: major_version
     }
 
-    with {:ok, %Xandra.Page{} = page} <- XandraUtils.retrieve_page(conn, statement, params) do
+    consistency = Consistency.domain_model(:read)
+
+    with {:ok, %Xandra.Page{} = page} <-
+           XandraUtils.retrieve_page(conn, statement, params, consistency: consistency) do
       case Enum.to_list(page) do
         [%{count: 1}] ->
           :ok

--- a/lib/astarte_data_access/mappings.ex
+++ b/lib/astarte_data_access/mappings.ex
@@ -18,6 +18,7 @@
 
 defmodule Astarte.DataAccess.Mappings do
   alias Astarte.Core.Mapping
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.XandraUtils
   require Logger
 
@@ -43,9 +44,11 @@ defmodule Astarte.DataAccess.Mappings do
     WHERE interface_id=:interface_id
     """
 
+    consistency = Consistency.domain_model(:read)
+
     with {:ok, %Xandra.Page{} = page} <-
            XandraUtils.retrieve_page(conn, statement, %{interface_id: interface_id},
-             consistency: :quorum
+             consistency: consistency
            ) do
       to_mapping_list(page)
     end


### PR DESCRIPTION
Define standard CL for queries and apply them to DataAccess functions.

Three consistency classes are introduced:
- "Domain model": everything related to realms, interfaces, triggers and Astarte entities in general.
- "Device info": everything related to a device status, e.g. connetion status, deletion in progress, property value etc.
- "Time series": datastreams.

Introduce sensible defaults for each class and allow the user to overwrite defaults.