### PR TITLE
chore(datetime): support for decimicrosecond datetime

### DIFF
--- a/lib/astarte_data_access/datetime.ex
+++ b/lib/astarte_data_access/datetime.ex
@@ -21,6 +21,7 @@ defmodule Astarte.DataAccess.DateTime do
   Ecto type for DateTimes with millisecond precision.
   """
   use Ecto.Type
+  alias Astarte.Core.DecimicrosecondDateTime
 
   @type t :: DateTime.t()
 
@@ -29,6 +30,7 @@ defmodule Astarte.DataAccess.DateTime do
 
   @spec load(t() | any()) :: {:ok, t()} | :error
   def load(%DateTime{} = datetime), do: {:ok, datetime}
+  def load(%DecimicrosecondDateTime{} = datetime), do: {:ok, datetime.datetime}
 
   def load(timestamp) when is_integer(timestamp),
     do: {:ok, DateTime.from_unix!(timestamp, :millisecond)}
@@ -39,18 +41,29 @@ defmodule Astarte.DataAccess.DateTime do
   @spec dump(t() | any()) :: {:ok, t()} | :error
   def dump(%DateTime{} = datetime), do: {:ok, datetime}
   def dump(timestamp) when is_integer(timestamp), do: {:ok, timestamp}
+
+  def dump(%DecimicrosecondDateTime{} = datetime),
+    do: {:ok, DecimicrosecondDateTime.to_unix(datetime, :millisecond)}
+
   def dump(_other), do: :error
 
   @spec cast(t() | any()) :: {:ok, t()} | :error
   def cast(datetime_or_timestamp_or_any), do: load(datetime_or_timestamp_or_any)
 
-  def split_submillis(timestamp) do
-    timestamp_ms = DateTime.truncate(timestamp, :millisecond)
-    submillis = timestamp |> DateTime.to_unix(:microsecond) |> rem(1000)
+  def split_submillis(datetime = %DateTime{}) do
+    timestamp_ms = DateTime.truncate(datetime, :millisecond)
+    submillis = datetime |> DateTime.to_unix(:microsecond) |> rem(1000)
     # `DateTime`s are microsecond precision, individual_properties's submillis
     # have one extra digit. Keep the unit consistent with DUP
     decimicrosecond_submillis = submillis * 10
 
     {timestamp_ms, decimicrosecond_submillis}
+  end
+
+  def split_submillis(datetime = %DecimicrosecondDateTime{}) do
+    timestamp_ms = DecimicrosecondDateTime.to_unix(datetime, :millisecond)
+    submillis = DecimicrosecondDateTime.to_unix(datetime, :decimicrosecond) |> rem(10000)
+
+    {timestamp_ms, submillis}
   end
 end

--- a/lib/astarte_data_access/datetime.ex
+++ b/lib/astarte_data_access/datetime.ex
@@ -29,7 +29,10 @@ defmodule Astarte.DataAccess.DateTime do
 
   @spec load(t() | any()) :: {:ok, t()} | :error
   def load(%DateTime{} = datetime), do: {:ok, datetime}
-  def load(timestamp) when is_integer(timestamp), do: {:ok, DateTime.from_unix!(timestamp)}
+
+  def load(timestamp) when is_integer(timestamp),
+    do: {:ok, DateTime.from_unix!(timestamp, :millisecond)}
+
   def load(_other), do: :error
 
   # xandra accepts both integers and datetimes, it can do the job for us

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Astarte.DataAccess.Mixfile do
 
   defp astarte_required_modules(_) do
     [
-      {:astarte_core, github: "astarte-platform/astarte_core", branch: "release-1.2"}
+      {:astarte_core, github: "noaccOS/astarte_core", branch: "chore/decimicro"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "7ba3d8f672e54c55b0abe8fd7c4d00f40a4f023e", [branch: "release-1.2"]},
+  "astarte_core": {:git, "https://github.com/noaccOS/astarte_core.git", "ca2c71612f421a68e77df85b820eb2c3e8d3aeab", [branch: "chore/decimicro"]},
   "castore": {:hex, :castore, "1.0.12", "053f0e32700cbec356280c0e835df425a3be4bc1e0627b714330ad9d0f05497f", [:mix], [], "hexpm", "3dca286b2186055ba0c9449b4e95b97bf1b57b47c1f2644555879e659960c224"},
   "cqerl": {:hex, :cqerl, "2.1.3", "bab07ea05fabf524112eaf199c349bbb05bc7cc2ac3655db117650ff86c963ec", [:rebar3], [{:lz4, "~> 0.2.4", [hex: :lz4_erl, repo: "hexpm", optional: false]}, {:re2, "1.9.8", [hex: :re2, repo: "hexpm", optional: false]}, {:semver, "~> 0.0.1", [hex: :semver_erl, repo: "hexpm", optional: false]}, {:snappyer, "1.2.8", [hex: :snappyer, repo: "hexpm", optional: false]}, {:uuid, "~> 2.0.0", [hex: :uuid_erl, repo: "hexpm", optional: false]}], "hexpm", "41cd201b4abc6985b34191dcd871cb50cbbb3e9db4ebfb7a2d7af5b5e3dbc43f"},
   "cqex": {:hex, :cqex, "1.0.1", "bc9980ac3b82d039879f8d6ca589deab799fe08f80ff449d60ad709f2524718f", [:mix], [{:cqerl, "~> 2.0.1", [hex: :cqerl, repo: "hexpm", optional: false]}], "hexpm", "1bbf2079c044cbf0f747f60dcf0409a951eaa8f1a2447cd6d80d6ff1b7c4dc6b"},


### PR DESCRIPTION
additionally, fix timestamp unit for integers in `load`

depends on https://github.com/astarte-platform/astarte_core/pull/119