### PR TITLE
Add missing uuid type to kv_store

### DIFF
--- a/lib/astarte_data_access/kv_store.ex
+++ b/lib/astarte_data_access/kv_store.ex
@@ -60,6 +60,7 @@ defmodule Astarte.DataAccess.KvStore do
         :integer -> "intAsBlob(?)"
         :big_integer -> "bigintAsBlob(?)"
         :string -> "varcharAsBlob(?)"
+        :uuid -> "uuidAsBlob(?)"
       end
 
     kv_store = %__MODULE__{


### PR DESCRIPTION
add missing uuid type to kv_store, this type is required by Astarte RealmManagement service in order to correctly create triggers