### PR TITLE
Define standard health check function for Astarte Services 

### DIFF
--- a/lib/astarte_data_access/data.ex
+++ b/lib/astarte_data_access/data.ex
@@ -19,7 +19,6 @@
 defmodule Astarte.DataAccess.Data do
   require Logger
   alias Astarte.DataAccess.Consistency
-  alias Astarte.DataAccess.XandraUtils
   import Ecto.Query
   alias Astarte.Core.CQLUtils
   alias Astarte.Core.Device

--- a/lib/astarte_data_access/device.ex
+++ b/lib/astarte_data_access/device.ex
@@ -19,7 +19,6 @@
 defmodule Astarte.DataAccess.Device do
   require Logger
   alias Astarte.DataAccess.Consistency
-  alias Astarte.DataAccess.XandraUtils
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.DataAccess.Devices.Device
   alias Astarte.DataAccess.Repo

--- a/lib/astarte_data_access/health/health.ex
+++ b/lib/astarte_data_access/health/health.ex
@@ -1,0 +1,43 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataAccess.Health.Health do
+  alias Astarte.DataAccess.Health.Queries
+
+  def get_health do
+    case Queries.check_astarte_health(:quorum) do
+      :ok ->
+        {:ok, %{status: :ready}}
+
+      {:error, :health_check_bad} ->
+        case Queries.check_astarte_health(:one) do
+          :ok ->
+            {:ok, %{status: :degraded}}
+
+          {:error, :health_check_bad} ->
+            {:ok, %{status: :bad}}
+
+          {:error, :database_connection_error} ->
+            {:ok, %{status: :error}}
+        end
+
+      {:error, :database_connection_error} ->
+        {:ok, %{status: :error}}
+    end
+  end
+end

--- a/lib/astarte_data_access/health/queries.ex
+++ b/lib/astarte_data_access/health/queries.ex
@@ -1,0 +1,73 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataAccess.Health.Queries do
+  alias Astarte.DataAccess.KvStore
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Repo
+
+  import Ecto.Query
+  require Logger
+
+  def check_astarte_health(consistency) do
+    astarte_keyspace = Realm.astarte_keyspace_name()
+
+    schema_query =
+      from kv in KvStore,
+        prefix: ^astarte_keyspace,
+        where: kv.group == "astarte" and kv.key == "schema_version",
+        select: count(kv.value)
+
+    realm_query =
+      from Realm,
+        prefix: ^astarte_keyspace,
+        where: [realm_name: "_invalid^name_"]
+
+    opts = [consistency: consistency]
+
+    with {:ok, _result} <- safe_query(schema_query, opts),
+         {:ok, _result} <- safe_query(realm_query, opts) do
+      :ok
+    else
+      error -> error
+    end
+  end
+
+  defp safe_query(ecto_query, opts) do
+    {sql, params} = Repo.to_sql(:all, ecto_query)
+
+    case Repo.query(sql, params, opts) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, %Xandra.ConnectionError{} = error} ->
+        Logger.warning("Database connection error #{Exception.message(error)}.",
+          tag: "database_connection_error"
+        )
+
+        {:error, :database_connection_error}
+
+      {:error, %Xandra.Error{} = error} ->
+        Logger.warning("Health is not good: #{Exception.message(error)}",
+          tag: "db_health_check_bad"
+        )
+
+        {:error, :health_check_bad}
+    end
+  end
+end

--- a/lib/astarte_data_access/interface.ex
+++ b/lib/astarte_data_access/interface.ex
@@ -20,7 +20,6 @@ defmodule Astarte.DataAccess.Interface do
   require Logger
   alias Astarte.Core.InterfaceDescriptor
   alias Astarte.DataAccess.Consistency
-  alias Astarte.DataAccess.XandraUtils
 
   import Ecto.Query
 

--- a/lib/astarte_data_access/mappings.ex
+++ b/lib/astarte_data_access/mappings.ex
@@ -22,7 +22,6 @@ defmodule Astarte.DataAccess.Mappings do
   alias Astarte.Core.Mapping
 
   alias Astarte.DataAccess.Consistency
-  alias Astarte.DataAccess.XandraUtils
 
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.DataAccess.Realms.Endpoint


### PR DESCRIPTION
Add `get_health` function that provides the health status of Astarte services. The health status returned can be:
- `:ready`,
- `:degraded`,
- `:bad`,
- `:error`.
