### PR TITLE
fix: `value_type()` type support `:uuid`s

### DIFF
--- a/lib/astarte_data_access/kv_store.ex
+++ b/lib/astarte_data_access/kv_store.ex
@@ -22,7 +22,7 @@ defmodule Astarte.DataAccess.KvStore do
 
   import Ecto.Query
 
-  @type value_type :: :binary | :integer | :big_integer | :string
+  @type value_type :: :binary | :integer | :big_integer | :string | :uuid
   @source "kv_store"
 
   @primary_key false
@@ -85,6 +85,7 @@ defmodule Astarte.DataAccess.KvStore do
         :integer -> dynamic([kv], fragment("blobAsInt(?)", kv.value))
         :big_integer -> dynamic([kv], fragment("blobAsBigint(?)", kv.value))
         :string -> dynamic([kv], fragment("blobAsVarChar(?)", kv.value))
+        :uuid -> dynamic([kv], fragment("blobAsUuid(?)", kv.value))
       end
 
     query = from(__MODULE__, select: ^value_expr)


### PR DESCRIPTION
`:uuid` type was contemplated for insertion but not for fetches, and the `value_type()` type did not include `:uuid`. This caused problems with dialyzer in functions calling `KvStore.insert`. This commit fixes this