### PR TITLE
fix: address dyalizer errors

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -49,8 +49,7 @@ jobs:
       if: ${{steps.plt_cache.outputs.cache-hit != 'true'}}
       run: mkdir -p dialyzer_cache && mix dialyzer --plt
     - name: Run dialyzer
-      # FIXME: This should be set to fail when dialyzer issues are fixed
-      run: mix dialyzer || exit 0
+      run: mix dialyzer
 
   test-coverage:
     name: Build and Test

--- a/lib/astarte_data_access.ex
+++ b/lib/astarte_data_access.ex
@@ -32,7 +32,7 @@ defmodule Astarte.DataAccess do
       {Astarte.DataAccess.Repo, xandra_options}
     ]
 
-    opts = [strategy: :one_for_one, name: Astarte.DataAccess.Supervisor]
+    opts = [strategy: :one_for_one]
     Supervisor.init(children, opts)
   end
 end

--- a/lib/astarte_data_access/data.ex
+++ b/lib/astarte_data_access/data.ex
@@ -67,14 +67,7 @@ defmodule Astarte.DataAccess.Data do
 
     consistency = Consistency.device_info(:read)
 
-    property =
-      Repo.fetch_by(query, fetch_clause, consistency: consistency, error: :property_not_set)
-
-    case property do
-      nil -> {:error, :property_not_set}
-      {:error, err} -> {:error, err}
-      {:ok, value} -> {:ok, value}
-    end
+    Repo.fetch_by(query, fetch_clause, consistency: consistency, error: :property_not_set)
   end
 
   @spec path_exists?(


### PR DESCRIPTION
Addresses  `mix dyalizer` errors and puts back in place `dyalizer` step in CI removing the old `|| exit 0`