### PR TITLE
chore: make `some?/2` return errors

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -49,8 +49,7 @@ jobs:
       if: ${{steps.plt_cache.outputs.cache-hit != 'true'}}
       run: mkdir -p dialyzer_cache && mix dialyzer --plt
     - name: Run dialyzer
-      # FIXME: This should be set to fail when dialyzer issues are fixed
-      run: mix dialyzer || exit 0
+      run: mix dialyzer
 
   test-coverage:
     name: Build and Test

--- a/lib/astarte_data_access.ex
+++ b/lib/astarte_data_access.ex
@@ -32,7 +32,7 @@ defmodule Astarte.DataAccess do
       {Astarte.DataAccess.Repo, xandra_options}
     ]
 
-    opts = [strategy: :one_for_one, name: Astarte.DataAccess.Supervisor]
+    opts = [strategy: :one_for_one]
     Supervisor.init(children, opts)
   end
 end

--- a/lib/astarte_data_access/data.ex
+++ b/lib/astarte_data_access/data.ex
@@ -67,14 +67,7 @@ defmodule Astarte.DataAccess.Data do
 
     consistency = Consistency.device_info(:read)
 
-    property =
-      Repo.fetch_by(query, fetch_clause, consistency: consistency, error: :property_not_set)
-
-    case property do
-      nil -> {:error, :property_not_set}
-      {:error, err} -> {:error, err}
-      {:ok, value} -> {:ok, value}
-    end
+    Repo.fetch_by(query, fetch_clause, consistency: consistency, error: :property_not_set)
   end
 
   @spec path_exists?(

--- a/lib/astarte_data_access/repo.ex
+++ b/lib/astarte_data_access/repo.ex
@@ -225,7 +225,8 @@ defmodule Astarte.DataAccess.Repo do
     # `fetch_one` is safe as we're limiting to 1 here, it should not raise
     case fetch_one(queryable, opts) do
       {:ok, _} -> {:ok, true}
-      {:error, _} -> {:ok, false}
+      {:error, :not_found} -> {:ok, false}
+      other_error -> other_error
     end
   end
 


### PR DESCRIPTION
Based on #110 

`some?/2` used to not return errors because of an incorrect match. Fixing its behavior.