### PR TITLE
refactor!: lift the curse from `get_health`

### DIFF
--- a/lib/astarte_data_access/health/health.ex
+++ b/lib/astarte_data_access/health/health.ex
@@ -22,22 +22,17 @@ defmodule Astarte.DataAccess.Health.Health do
   def get_health do
     case Queries.check_astarte_health(:quorum) do
       :ok ->
-        {:ok, %{status: :ready}}
+        :ready
 
       {:error, :health_check_bad} ->
         case Queries.check_astarte_health(:one) do
-          :ok ->
-            {:ok, %{status: :degraded}}
-
-          {:error, :health_check_bad} ->
-            {:ok, %{status: :bad}}
-
-          {:error, :database_connection_error} ->
-            {:ok, %{status: :error}}
+          :ok -> :degraded
+          {:error, :health_check_bad} -> :bad
+          {:error, :database_connection_error} -> :error
         end
 
       {:error, :database_connection_error} ->
-        {:ok, %{status: :error}}
+        :error
     end
   end
 end


### PR DESCRIPTION
the success typing of `Health.get_health/0` was
```
{:ok, %{status: :ready | :bad | :degraded | :error}}
```

this is incredibly cursed, as both `:ok` the `%{status: }` parts are completely unnecessary.

BREAKING CHANGE: The return type of `Astarte.DataAccess.Health.Health.get_health/0` changes from `{:ok, %{status: :ready | :bad | :degraded | :error}}` to `:ready | :bad | :degraded | :error`, this way users do not need to match on the unnecessary `{:ok, %{status: }}` and can focus on what matters.