### PR TITLE
Backport: feat: add keepalive option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-rc.1] - Unreleased
+### Added
+- Add the `CASSANDRA_ENABLE_KEEPALIVE` env to enable or disable the keepalive option for the xandra
+  connection. This is enabled by default
+
 ## [1.2.1-rc.0] - 2025-08-22
 ### Added
 - Ecto schemas for Astarte database resources and a repo with common functionality


### PR DESCRIPTION
add a wrapper around the keepalive transport option, which is enabled by default as it resolves a connection issue with scylla cloud

backported from release-1.3